### PR TITLE
chore(repay-scripts): Upgrade @repay/babel-preset & publish v0.2.2

### DIFF
--- a/modules/repay-scripts/package.json
+++ b/modules/repay-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repay/scripts",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "a build tool for developing front-end applications at REPAY",
   "author": "JamesNimlos <jnimlos@repay.com>",
   "homepage": "https://github.com/repaygithub/repay-ui#readme",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.3.4",
-    "@repay/babel-preset": "^0.1.2",
+    "@repay/babel-preset": "^0.2.0",
     "babel-loader": "^8.0.5",
     "file-loader": "^3.0.1",
     "html-webpack-plugin": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -925,30 +925,6 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/yargs" "^12.0.9"
 
-"@repay/babel-preset@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@repay/babel-preset/-/babel-preset-0.1.2.tgz#534edbbbc59cb069e1a69ab04e5b8bbdd4b83675"
-  integrity sha512-PwAAtVLjTZZv5mXvkOztIpPO9ni9vHkgbraCOXEly5ajCrSI8uVe9fkxN2Vw/8krNoTQEbsli4IKpglSi6Babg==
-  dependencies:
-    "@babel/plugin-proposal-class-properties" "^7.3.4"
-    "@babel/plugin-proposal-object-rest-spread" "^7.3.4"
-    "@babel/plugin-transform-destructuring" "^7.3.2"
-    "@babel/preset-env" "^7.3.4"
-    "@babel/preset-react" "^7.0.0"
-    "@babel/preset-typescript" "^7.3.3"
-
-"@repay/eslint-config@./modules/eslint-config":
-  version "1.1.1"
-  dependencies:
-    "@babel/core" "^7.3.4"
-    "@babel/plugin-proposal-optional-chaining" "^7.0.0"
-    babel-eslint "^10.0.1"
-    eslint-config-prettier "^3.0.1"
-    eslint-config-react "^1.1.7"
-    eslint-plugin-prettier "^3.0.0"
-    eslint-plugin-react "^7.11.1"
-    eslint-plugin-react-hooks "^1.5.1"
-
 "@types/babel__core@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.0.tgz#710f2487dda4dcfd010ca6abb2b4dc7394365c51"

--- a/yarn.lock
+++ b/yarn.lock
@@ -925,6 +925,18 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/yargs" "^12.0.9"
 
+"@repay/eslint-config@./modules/eslint-config":
+  version "1.1.1"
+  dependencies:
+    "@babel/core" "^7.3.4"
+    "@babel/plugin-proposal-optional-chaining" "^7.0.0"
+    babel-eslint "^10.0.1"
+    eslint-config-prettier "^3.0.1"
+    eslint-config-react "^1.1.7"
+    eslint-plugin-prettier "^3.0.0"
+    eslint-plugin-react "^7.11.1"
+    eslint-plugin-react-hooks "^1.5.1"
+
 "@types/babel__core@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.0.tgz#710f2487dda4dcfd010ca6abb2b4dc7394365c51"


### PR DESCRIPTION
Upgraded `@repay/babel-preset` in `repay-scripts` so we'd have access to dynamic import syntax and published v0.2.2