### PR TITLE
Add react/react-in-jsx-scope to eslint-config

### DIFF
--- a/modules/eslint-config/index.js
+++ b/modules/eslint-config/index.js
@@ -48,6 +48,7 @@ module.exports = {
     'react/jsx-curly-brace-presence': ['error', { props: 'never', children: 'ignore' }],
     'react/no-string-refs': 'error',
     'react/no-direct-mutation-state': 'error',
+    'react/react-in-jsx-scope': 'error',
     'react/require-render-return': 'error',
     'react/jsx-no-duplicate-props': 'error',
     'react-hooks/rules-of-hooks': 'error',


### PR DESCRIPTION
This rule is a nice safety net to catch you when you forget to import `React` into a JSX file