### PR TITLE
fix(repay-scripts): Await the webpack config call in case it's async

### DIFF
--- a/modules/repay-scripts/src/commands/build.js
+++ b/modules/repay-scripts/src/commands/build.js
@@ -120,7 +120,8 @@ async function build(options) {
     logger.debug({ input })
     let config = getWebpackConfig(input, options)
     if (options.config) {
-      config = require(options.config)(config, options)
+      const configFromOptions = require(options.config)
+      config = await configFromOptions(config, options)
       logger.debug('webpack configuration', config)
       delete config.devServer
     }


### PR DESCRIPTION
As I was working on [this](https://repayonline.atlassian.net/browse/CACTUS-256) ticket, I was having issues with the build and realized it's because we have to have an async webpack config function in the SSO theme. I added `await` before we call the config function which seemed to fix the issue (tested it with the linked package). This also shouldn't be a problem for configs that aren't async, as `await`ing a non-async function in JS is acceptable.

## Testing
1. Check out this branch, add a log statement somewhere in `build.js` to make sure you're using the linked package, and run `yarn link` in the `repay-scripts` folder.
2. In the cactus repo, run `yarn link @repay/scripts` at the root.
3. Navigate to `examples/theme-components` & run `yarn build`
4. Make sure you were able to see your log statement and verify that the app built successfully