### PR TITLE
CACTUS-271 :: Repay Scripts Improvements

### DIFF
--- a/modules/repay-scripts/src/cli.js
+++ b/modules/repay-scripts/src/cli.js
@@ -44,6 +44,11 @@ function cli(cwd) {
       description: 'enables treeshaking for libraries',
       default: false,
     },
+    watch: {
+      type: 'boolean',
+      description: 'applies to "build" only - watches files and rebuilds on change',
+      default: false,
+    },
   })
 
   parser.command(
@@ -74,6 +79,7 @@ function cli(cwd) {
 function parseToConfig(argv) {
   const cwd = process.cwd()
   let config = argv.config
+  const command = argv._[0]
 
   if (argv.config !== null) {
     const configPath = path.resolve(argv.config)
@@ -86,6 +92,10 @@ function parseToConfig(argv) {
 
   if (!argv.lib && argv['tree-shaking']) {
     logger.log('--tree-shaking is only applied on libraries')
+  }
+
+  if (command !== 'build' && argv.watch) {
+    logger.log('--watch is only valid on the build command')
   }
 
   if (argv['babel-env']) {
@@ -104,5 +114,6 @@ function parseToConfig(argv) {
     entry: argv.entry,
     lib: argv.lib,
     treeShaking: argv['tree-shaking'],
+    watch: argv.watch,
   }
 }

--- a/modules/repay-scripts/src/commands/dev.js
+++ b/modules/repay-scripts/src/commands/dev.js
@@ -104,7 +104,8 @@ async function dev(options) {
     }
     if (options.config) {
       config.devServer = serverConfig
-      config = require(options.config)(config, options)
+      const configFromOptions = require(options.config)
+      config = await configFromOptions(config, options)
       logger.debug('webpack configuration', config)
       serverConfig = config.devServer
       delete config.devServer

--- a/modules/repay-scripts/src/configs/web.js
+++ b/modules/repay-scripts/src/configs/web.js
@@ -43,14 +43,13 @@ function getWebpackConfig(input, { cwd, env, port }) {
           test: /\.css$/,
           use: [
             {
-              loader: 'style-loader',
+              loader: require.resolve('style-loader'),
             },
             {
-              loader: 'css-loader',
+              loader: require.resolve('css-loader'),
               options: {
                 sourceMap: true,
-                modules: true,
-                localIdentName: '[name]__[local]___[hash:base64:5]',
+                modules: { localIdentName: '[name]__[local]___[hash:base64:5]' },
               },
             },
           ],

--- a/modules/repay-scripts/src/repay-scripts.js
+++ b/modules/repay-scripts/src/repay-scripts.js
@@ -12,7 +12,8 @@ async function repayScripts(options) {
   logger.debug(options)
   switch (command) {
     case 'build': {
-      options.env = 'production'
+      const isWatch = options.watch
+      options.env = isWatch ? 'development' : 'production'
       await build(options)
       break
     }


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-271

This doesn't contribute directly to the ticket.  Instead, it adds some features that help the SSO Image use `repay-scripts`.  These include:

* Adding a `--watch` option to the `build` command.  `dev` doesn't apply for the SSO image, since it doesn't use webpack dev server.
* Fix a couple of bugs with the CSS/Style Loaders
* Add the ability to use async config functions with the `dev` command.  (I guess this doesn't really help the SSO image, since it doesn't use `dev`.  I made this change when I initially thought it could, and it seems useful enough to keep).

### Testing

* Pull down this branch and link it to an app that uses `@repay/scripts` (like the Cactus example apps).  Run `yarn build` to make sure that works normally.  Run `yarn build --watch`, and then make a change to a file.  You should see it rebuild.  Run `yarn dev` to make sure that that command still works as expected.
* Be sure you're testing in an app that uses CSS extensively (i.e. the Cactus example apps).  Make sure all the component styles look normal.