### PR TITLE
Upgrade Prettier to v2

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,0 @@
-coverage/
-dist/
-node_modules/
-package-lock.json
-yarn.lock
-package.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,0 @@
-{
-  "singleQuote": true,
-  "semi": false,
-  "trailingComma": "es5",
-  "printWidth": 100
-}

--- a/modules/eslint-config/gateway-example.js
+++ b/modules/eslint-config/gateway-example.js
@@ -27,7 +27,7 @@ class StatusForm extends Component {
   }
 
   getStatus() {
-    getStatus().then(response => {
+    getStatus().then((response) => {
       if (response.statusCode == 200) {
         this.setState({
           repayStatus: response.result,
@@ -44,7 +44,7 @@ class StatusForm extends Component {
       <div>
         <h2>Scheduled Maintenance</h2>
         {upcomingOrdered
-          ? upcomingOrdered.map(item => {
+          ? upcomingOrdered.map((item) => {
               return (
                 <div className="panel" style={{ width: '800px' }} key={`parent-${item.id}`}>
                   <div className="panel-heading">{item.name}</div>
@@ -62,7 +62,7 @@ class StatusForm extends Component {
                           <tr>
                             <td style={{ fontWeight: 'bold' }}>Components</td>
                             <td>
-                              {item.componentsAffected.map(component => {
+                              {item.componentsAffected.map((component) => {
                                 return <div key={`component-${component.id}`}>{component.name}</div>
                               })}
                             </td>
@@ -70,7 +70,7 @@ class StatusForm extends Component {
                           <tr>
                             <td style={{ fontWeight: 'bold' }}>Locations</td>
                             <td>
-                              {item.containersAffected.map(location => {
+                              {item.containersAffected.map((location) => {
                                 return <div key={`location-${location.id}`}>{location.name}</div>
                               })}
                             </td>
@@ -78,7 +78,7 @@ class StatusForm extends Component {
                           <tr>
                             <td style={{ fontWeight: 'bold' }}>Description</td>
                             <td>
-                              {item.messages.map(message => {
+                              {item.messages.map((message) => {
                                 return <div key={`message-${messageId++}`}>{message.details}</div>
                               })}
                             </td>

--- a/modules/eslint-config/package.json
+++ b/modules/eslint-config/package.json
@@ -25,19 +25,19 @@
     "@babel/core": "^7.5.5",
     "@babel/plugin-proposal-optional-chaining": "^7.0.0",
     "babel-eslint": "^10.0.2",
-    "eslint-config-prettier": "^6.1.0",
+    "eslint-config-prettier": "^6.11.0",
     "eslint-config-react": "^1.1.7",
-    "eslint-plugin-prettier": "^3.1.0",
+    "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-react-hooks": "^2.0.1",
     "eslint-plugin-sort-imports-es6-autofix": "^0.4.0"
   },
   "devDependencies": {
     "eslint": "~6.1.0",
-    "prettier": "^1.18.2"
+    "prettier": "^2.0.5"
   },
   "peerDependencies": {
     "eslint": ">=5 && < 6.2.0",
-    "prettier": ">=1.14.2"
+    "prettier": ">=2.0.0"
   }
 }

--- a/modules/eslint-config/repay-api-example.js
+++ b/modules/eslint-config/repay-api-example.js
@@ -35,9 +35,9 @@ function getField({ fieldType, input, type, placeholder, disabled, options }) {
   )
 }
 
-const renderOptions = options => {
+const renderOptions = (options) => {
   if (options) {
-    return options.map(option => (
+    return options.map((option) => (
       <option key={option.value} value={option.value}>
         {option.name}
       </option>

--- a/modules/repay-scripts/src/cli.js
+++ b/modules/repay-scripts/src/cli.js
@@ -50,7 +50,7 @@ function cli(cwd) {
     'build <entry>',
     'build a javascript library or front-end application',
     () => {},
-    argv => repayScripts(parseToConfig(argv))
+    (argv) => repayScripts(parseToConfig(argv))
   )
 
   parser.command(
@@ -65,7 +65,7 @@ function cli(cwd) {
         requiresArgs: true,
       })
     },
-    argv => repayScripts(parseToConfig(argv))
+    (argv) => repayScripts(parseToConfig(argv))
   )
 
   return parser

--- a/modules/repay-scripts/src/commands/build.js
+++ b/modules/repay-scripts/src/commands/build.js
@@ -98,7 +98,7 @@ async function build(options) {
     logger.debug('starting rollup...')
     const bundle = await rollup.rollup(pick(config, inputOptions))
     logger.debug('finished bundling, staring rollup write...')
-    let writePromises = config.output.map(out => bundle.write(pick(out, outputOptions)))
+    let writePromises = config.output.map((out) => bundle.write(pick(out, outputOptions)))
 
     if (options.treeShaking) {
       logger.debug('starting babel...')

--- a/modules/repay-scripts/src/commands/dev.js
+++ b/modules/repay-scripts/src/commands/dev.js
@@ -20,7 +20,7 @@ async function dev(options) {
     }
     logger.debug('building library...')
     let watcher = rollup.watch(config)
-    watcher.on('event', event => {
+    watcher.on('event', (event) => {
       if (event.code === 'ERROR') {
         console.error('Error generating bundle')
         console.error(event.error)
@@ -42,7 +42,7 @@ async function dev(options) {
 
       function addToWatch(from) {
         watchedFiles.add(from)
-        fs.watch(from, eventType => {
+        fs.watch(from, (eventType) => {
           logger.debug(eventType, from)
           files.push(from)
           transpileFiles()
@@ -122,7 +122,7 @@ async function dev(options) {
       }
     })
 
-    compiler.hooks.done.tap('done', async stats => {
+    compiler.hooks.done.tap('done', async (stats) => {
       // We have switched off the default Webpack output in WebpackDevServer
       const statsData = stats.toJson({
         all: false,
@@ -162,14 +162,14 @@ async function dev(options) {
     })
 
     const devServer = new webpackDevServer(compiler, serverConfig)
-    devServer.listen(PORT, HOST, err => {
+    devServer.listen(PORT, HOST, (err) => {
       if (err) {
         return logger.log(err)
       }
       logger.log('Building web application...')
     })
-    ;['SIGINT', 'SIGTERM'].forEach(function(sig) {
-      process.on(sig, function() {
+    ;['SIGINT', 'SIGTERM'].forEach(function (sig) {
+      process.on(sig, function () {
         devServer.close(() => {
           process.exit()
         })

--- a/modules/repay-scripts/src/configs/rollup.js
+++ b/modules/repay-scripts/src/configs/rollup.js
@@ -26,7 +26,7 @@ function getRollupConfig(input, { cwd, treeShaking, babelEnv }) {
   )
   return {
     input,
-    external: id => externalDeps.some(name => id.startsWith(name)),
+    external: (id) => externalDeps.some((name) => id.startsWith(name)),
     output: [
       pkg.module &&
         !treeShaking && {

--- a/modules/repay-scripts/src/helpers/babelTranspiler.js
+++ b/modules/repay-scripts/src/helpers/babelTranspiler.js
@@ -35,7 +35,7 @@ module.exports = {
         let depPath = path.resolve(from.replace(path.basename(from), ''), source)
         let ext = path.extname(source)
         if (!ext) {
-          ext = ['.ts', '.tsx', '.js', '.jsx'].find(e => fs.existsSync(depPath + e))
+          ext = ['.ts', '.tsx', '.js', '.jsx'].find((e) => fs.existsSync(depPath + e))
         }
         depPath = depPath + ext
         if (depPath.includes('placeholder')) {

--- a/modules/repay-scripts/src/helpers/logger.js
+++ b/modules/repay-scripts/src/helpers/logger.js
@@ -5,5 +5,5 @@ const debug = (...args) => void (__DEBUG__ && log('[DEBUG]', ...args))
 module.exports = {
   log,
   debug,
-  setDebug: debug => (__DEBUG__ = Boolean(debug)),
+  setDebug: (debug) => (__DEBUG__ = Boolean(debug)),
 }

--- a/modules/repay-scripts/tests/repay-scripts-build/react-application.test.js
+++ b/modules/repay-scripts/tests/repay-scripts-build/react-application.test.js
@@ -11,7 +11,7 @@ describe('@repay/repay-scripts', () => {
     test.startServer()
     const page = await test.getPage()
     await page.goto('http://localhost:8100')
-    const content = await page.$eval('.react-root', el => el.parentElement.outerHTML)
+    const content = await page.$eval('.react-root', (el) => el.parentElement.outerHTML)
     expect(content).toMatchSnapshot()
   })
 })

--- a/modules/repay-scripts/tests/repay-scripts-build/react-library.test.js
+++ b/modules/repay-scripts/tests/repay-scripts-build/react-library.test.js
@@ -35,7 +35,7 @@ describe('@repay/repay-scripts', () => {
     const page = await test.getPage()
     await page.goto('http://localhost:8100')
     // wait for react-library className
-    const content = await page.$eval('.AppWrapper', el => el.parentElement.outerHTML)
+    const content = await page.$eval('.AppWrapper', (el) => el.parentElement.outerHTML)
     expect(content).toMatchSnapshot()
   })
 
@@ -55,7 +55,7 @@ describe('@repay/repay-scripts', () => {
     const page = await test.getPage()
     await page.goto('http://localhost:8100')
     // wait for react-library className
-    const content = await page.$eval('.AppWrapper', el => el.parentElement.outerHTML)
+    const content = await page.$eval('.AppWrapper', (el) => el.parentElement.outerHTML)
     expect(content).toContain('Updated Text')
   })
 })

--- a/modules/repay-scripts/tests/repay-scripts-build/web-application.test.js
+++ b/modules/repay-scripts/tests/repay-scripts-build/web-application.test.js
@@ -11,7 +11,7 @@ describe('@repay/repay-scripts', () => {
     test.startServer()
     const page = await test.getPage()
     await page.goto('http://localhost:8100')
-    const content = await page.$eval('.app-root', el => el.outerHTML)
+    const content = await page.$eval('.app-root', (el) => el.outerHTML)
     expect(content).toMatchSnapshot()
   })
 })

--- a/modules/repay-scripts/tests/repay-scripts-dev/react-application.test.js
+++ b/modules/repay-scripts/tests/repay-scripts-dev/react-application.test.js
@@ -19,7 +19,7 @@ describe('@repay/repay-scripts', () => {
     await test.waitForText('Compiled successfully')
     const page = await test.getPage()
     await page.goto('https://localhost:9696')
-    const content = await page.$eval('.react-root', el => el.parentElement.outerHTML)
+    const content = await page.$eval('.react-root', (el) => el.parentElement.outerHTML)
     expect(content).toMatchSnapshot()
   })
 })

--- a/modules/repay-scripts/tests/repay-scripts-dev/react-library.test.js
+++ b/modules/repay-scripts/tests/repay-scripts-dev/react-library.test.js
@@ -4,8 +4,8 @@ const React = require('react')
 
 beforeEach(() => jest.setTimeout(1000 * 60 * 5))
 
-const sleep = seconds => {
-  return new Promise(resolve => {
+const sleep = (seconds) => {
+  return new Promise((resolve) => {
     setTimeout(resolve, seconds * 1000)
   })
 }
@@ -86,7 +86,7 @@ module.exports = function (config) {
     await page.goto('https://localhost:9444')
     // wait for react-library className
     await sleep(2)
-    const content = await page.$eval('.AppWrapper.Updated', el => el.parentElement.outerHTML)
+    const content = await page.$eval('.AppWrapper.Updated', (el) => el.parentElement.outerHTML)
     expect(content).toMatchSnapshot()
     await test.exec('yarn unlink')
   })

--- a/modules/repay-scripts/tests/repay-scripts-dev/web-application.test.js
+++ b/modules/repay-scripts/tests/repay-scripts-dev/web-application.test.js
@@ -19,7 +19,7 @@ describe('@repay/repay-scripts', () => {
     await test.waitForText('Compiled successfully')
     const page = await test.getPage()
     await page.goto('https://localhost:9696')
-    const content = await page.$eval('.app-root', el => el.outerHTML)
+    const content = await page.$eval('.app-root', (el) => el.outerHTML)
     expect(content).toMatchSnapshot()
   })
 })

--- a/modules/repay-scripts/tests/static-server.js
+++ b/modules/repay-scripts/tests/static-server.js
@@ -32,7 +32,7 @@ function startStaticServer({ directory, port }) {
   const notFoundPath = path.resolve(directory, './404.html')
 
   const server = http
-    .createServer(function(request, response) {
+    .createServer(function (request, response) {
       let url = request.url
       let filePath = path.join(directory, url)
       if (isForbidden(filePath)) {
@@ -47,15 +47,15 @@ function startStaticServer({ directory, port }) {
       let contentType = mimeTypes[extname] || 'application/octet-stream'
 
       fs.readFile(filePath)
-        .then(content => {
+        .then((content) => {
           response.writeHead(200, { 'Content-Type': contentType })
           response.end(content, 'utf-8')
         })
-        .catch(error => {
+        .catch((error) => {
           if (error.code === 'ENOENT') {
             fs.readFile(notFoundPath)
               .catch(() => 'Not Found')
-              .then(content => {
+              .then((content) => {
                 response.writeHead(404, { 'Content-Type': mimeTypes['.html'] })
                 response.end(content, 'utf-8')
               })
@@ -71,7 +71,7 @@ function startStaticServer({ directory, port }) {
     server,
     close() {
       return new Promise((resolve, reject) => {
-        server.close(error => {
+        server.close((error) => {
           if (error) {
             reject(error)
           } else {

--- a/modules/repay-scripts/tests/test-setup.js
+++ b/modules/repay-scripts/tests/test-setup.js
@@ -55,7 +55,7 @@ class TestSetup {
   }
 
   _dataUpdate() {
-    this._listeners.forEach(func => {
+    this._listeners.forEach((func) => {
       func(this._data)
     })
   }
@@ -80,7 +80,7 @@ class TestSetup {
       Array.prototype.push.apply(this._data, args)
       this._dataUpdate()
     }
-    this._childProcess.stdout.on('data', d => this._data.push(d.toString()))
+    this._childProcess.stdout.on('data', (d) => this._data.push(d.toString()))
     return this._childProcess
   }
 
@@ -120,7 +120,7 @@ class TestSetup {
           })
           this._childProcess.on('error', () => reject())
           psTree(this._childProcess.pid, (err, children) => {
-            children.forEach(c => {
+            children.forEach((c) => {
               try {
                 process.kill(c.PID, 'SIGKILL')
               } catch (e) {
@@ -135,8 +135,8 @@ class TestSetup {
   }
 
   waitForText(text, count = 1) {
-    return new Promise(resolve => {
-      const wasTextSeen = data => {
+    return new Promise((resolve) => {
+      const wasTextSeen = (data) => {
         let found = 0
         for (let i = 0; i < data.length; ++i) {
           const datum = data[i]
@@ -154,7 +154,7 @@ class TestSetup {
         if (wasTextSeen(this._data)) {
           resolve()
         } else {
-          const resolver = data => {
+          const resolver = (data) => {
             if (wasTextSeen(data)) {
               this.unsubscribe(resolver)
               resolve()

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "commitizen": "^4.1.2",
     "cz-conventional-changelog": "3.2.0",
     "eslint": "~6.1.0",
-    "prettier": "^1.18.2"
+    "prettier": "^2.0.5"
   },
   "resolutions": {
     "**/eslint-utils": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -961,9 +961,9 @@
     "@babel/core" "^7.5.5"
     "@babel/plugin-proposal-optional-chaining" "^7.0.0"
     babel-eslint "^10.0.2"
-    eslint-config-prettier "^6.1.0"
+    eslint-config-prettier "^6.11.0"
     eslint-config-react "^1.1.7"
-    eslint-plugin-prettier "^3.1.0"
+    eslint-plugin-prettier "^3.1.4"
     eslint-plugin-react "^7.14.3"
     eslint-plugin-react-hooks "^2.0.1"
     eslint-plugin-sort-imports-es6-autofix "^0.4.0"
@@ -2948,10 +2948,10 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-prettier@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.1.0.tgz#e6f678ba367fbd1273998d5510f76f004e9dce7b"
-  integrity sha512-k9fny9sPjIBQ2ftFTesJV21Rg4R/7a7t7LCtZVrYQiHEp8Nnuk3EGaDmsKSAnsPj0BYcgB2zxzHa2NTkIxcOLg==
+eslint-config-prettier@^6.11.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz#f6d2238c1290d01c859a8b5c1f7d352a0b0da8b1"
+  integrity sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==
   dependencies:
     get-stdin "^6.0.0"
 
@@ -2960,10 +2960,10 @@ eslint-config-react@^1.1.7:
   resolved "https://registry.yarnpkg.com/eslint-config-react/-/eslint-config-react-1.1.7.tgz#a0918d0fc47d0e9bd161a47308021da85d2585b3"
   integrity sha1-oJGND8R9DpvRYaRzCAIdqF0lhbM=
 
-eslint-plugin-prettier@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz#8695188f95daa93b0dc54b249347ca3b79c4686d"
-  integrity sha512-XWX2yVuwVNLOUhQijAkXz+rMPPoCr7WFiAl8ig6I7Xn+pPVhDhzg4DxHpmbeb0iqjO9UronEA3Tb09ChnFVHHA==
+eslint-plugin-prettier@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz#168ab43154e2ea57db992a2cd097c828171f75c2"
+  integrity sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
@@ -6242,10 +6242,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.18.2:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
 pretty-error@^2.0.2:
   version "2.1.1"


### PR DESCRIPTION
v2 of Prettier includes a few syntax changes that we should probably start including.  Plus a few
repos have pulled it in already, so we should probably start to standardize.

### How to Test

Pull down this branch, run `yarn install`, and then link this module to another repo (like Cactus).  Make sure that linting still works in your editor and in the command line.  One thing you should notice is that single-argument arrow functions now require parens, so you should see that change highlighted in existing files.