### PR TITLE
CACTUS-300 :: Add polyfills to REPAY scripts

### DIFF
--- a/modules/babel-preset/README.md
+++ b/modules/babel-preset/README.md
@@ -41,3 +41,11 @@ Add the preset to your .babelrc or equivalent
   ```
 
 - Object rest spread (e.g. `let obj = {...props}`)
+
+## Polyfills
+
+There are two options you can pass to control polyfills:
+
+- `coreJsPolyfill` (default: `false`): When this option is `true`, the [`useBuiltIns: 'usage'`](https://babeljs.io/docs/en/babel-preset-env#usebuiltins-usage) option will be passed into `@babel/preset-env` to automatically
+add in only the necessary CoreJS polyfills needed.
+- `regeneratorPolyfill` (default: `false`): When this option is `true`, the [`regenerator: true`](https://babeljs.io/docs/en/babel-plugin-transform-runtime#regenerator) option will be passed into the `@babel/plugin-transform-runtime` plugin.

--- a/modules/babel-preset/README.md
+++ b/modules/babel-preset/README.md
@@ -6,12 +6,12 @@ Babel preset used by [@repaygithub](https://github.com/repaygithub/)
 
 Install via the command line using yarn or npm
 
-> `@babel/core` is a peer dependency, which means you must install it yourself.
+> `@babel/core`, `@babel/runtime`, and `core-js` are peer dependencies, which means you must install them yourself.
 
 ```bash
-yarn add --dev @repay/babel-preset @babel/core
+yarn add --dev @repay/babel-preset @babel/core @babel/runtime core-js
 # OR
-npm install --save-dev @repay/babel-preset @babel/core
+npm install --save-dev @repay/babel-preset @babel/core @babel/runtime core-js
 ```
 
 Add the preset to your .babelrc or equivalent

--- a/modules/babel-preset/index.js
+++ b/modules/babel-preset/index.js
@@ -1,4 +1,7 @@
-module.exports = function babelPreset(api, options = { polyfill: false, useHelpers: false }) {
+module.exports = function babelPreset(
+  api,
+  options = { coreJsPolyfill: false, regeneratorPolyfill: false, useHelpers: false }
+) {
   const isEnvProduction = api.env('production')
   const isEnvTest = api.env('test')
   const isEnvDevelopment = api.env('development') || (!isEnvProduction && !isEnvTest)
@@ -25,7 +28,9 @@ module.exports = function babelPreset(api, options = { polyfill: false, useHelpe
           // configuration is highly tuned for ES5 support
           ignoreBrowserslistConfig: true,
           // polyfills based on usage, otherwise assumes polyfills are provided
-          ...(options.polyfill ? { corejs: 3, useBuiltIns: 'usage' } : { useBuiltIns: false }),
+          ...(options.coreJsPolyfill
+            ? { corejs: 3, useBuiltIns: 'usage' }
+            : { useBuiltIns: false }),
           // Do not transform modules to CJS to allow code-splitting at bundling
           modules: false,
           // Exclude transforms that make all code slower
@@ -58,7 +63,7 @@ module.exports = function babelPreset(api, options = { polyfill: false, useHelpe
           // these polyfills are provided by @babel/preset-env or babel-polyfill
           corejs: false,
           // provides async support when auto polyfill is requested
-          regenerator: options.polyfill,
+          regenerator: options.regeneratorPolyfill,
           // avoids inlining helpers like _extend for smaller code size
           helpers: options.useHelpers,
           // smaller code size because no es module interop required

--- a/modules/babel-preset/package.json
+++ b/modules/babel-preset/package.json
@@ -22,9 +22,11 @@
   "devDependencies": {
     "@babel/core": "^7.5.5",
     "@babel/runtime": "^7.5.5",
-    "core-js": "^3.2.1"
+    "core-js": "^3.6.4"
   },
   "peerDependencies": {
-    "@babel/core": "^7.3.4"
+    "@babel/core": "^7.3.4",
+    "@babel/runtime": "^7.3.4",
+    "core-js": "^3.6.4"
   }
 }

--- a/modules/repay-scripts/package.json
+++ b/modules/repay-scripts/package.json
@@ -31,8 +31,10 @@
   },
   "dependencies": {
     "@babel/core": "^7.5.5",
+    "@babel/runtime": "^7.5.5",
     "@repay/babel-preset": "^0.3.0",
     "babel-loader": "^8.0.6",
+    "core-js": "^3.6.4",
     "css-loader": "^3.5.3",
     "file-loader": "^4.2.0",
     "html-webpack-plugin": "^4.3.0",

--- a/modules/repay-scripts/src/configs/babel.js
+++ b/modules/repay-scripts/src/configs/babel.js
@@ -2,7 +2,14 @@ let presets = null
 
 module.exports = function getBabelConfig() {
   if (presets === null) {
-    presets = [require.resolve('@repay/babel-preset')]
+    presets = [
+      [
+        require.resolve('@repay/babel-preset'),
+        // CoreJS manual included in webpack entry, as Babel polyfill doesn't work with Fluent
+        // Regenerator polyfill can be safely used with Babel, however
+        { coreJsPolyfill: false, regeneratorPolyfill: true, useHelpers: true },
+      ],
+    ]
   }
   return {
     presets: presets.slice(),

--- a/modules/repay-scripts/src/configs/web.js
+++ b/modules/repay-scripts/src/configs/web.js
@@ -11,12 +11,17 @@ function getWebpackConfig(input, { cwd, env, port, template }) {
   const isEnvProduction = env === 'production'
   const isEnvDevelopment = !isEnvProduction
   const templateExists = fs.existsSync(path.join(process.cwd(), template))
+  const polyfilledInput = [require.resolve('core-js/stable'), input]
   return {
     mode: isEnvProduction ? 'production' : 'development',
     devtool: 'cheap-module-source-map',
     entry: isEnvProduction
-      ? input
-      : [`webpack-dev-server/client?http://localhost:${port}/`, `webpack/hot/dev-server`, input],
+      ? polyfilledInput
+      : [
+          `webpack-dev-server/client?http://localhost:${port}/`,
+          `webpack/hot/dev-server`,
+          ...polyfilledInput,
+        ],
     output: {
       path: path.resolve(cwd, 'dist'),
       filename: `[name].${isEnvProduction ? '[contenthash]' : 'bundle'}.js`, // add contenthash for production build

--- a/yarn.lock
+++ b/yarn.lock
@@ -3501,10 +3501,10 @@ core-js@^2.4.0, core-js@^2.5.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
-core-js@^3.2.1:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.5.0.tgz#66df8e49be4bd775e6f952a9d083b756ad41c1ed"
-  integrity sha512-Ifh3kj78gzQ7NAoJXeTu+XwzDld0QRIwjBLRqAMhuLhP3d2Av5wmgE9ycfnvK6NAEjTkQ1sDPeoEZAWO3Hx1Uw==
+core-js@^3.6.4:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
+  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-300

Previously we weren't adding any polyfills with `@repay/scripts`.  Given that we support IE11, that's bad.  This PR adds them in.  We had to manually add them in for the CoreJS features, as Babel's `usage` polyfill option didn't seem to properly detect the necessary polyfills for the Fluent library.  For the regenerator polyfill, however, Babel's automatic option worked just fine.

### Testing

1. Run `yarn` to install the new dependencies
2. Run `yarn link` inside `modules/babel-preset`
3. Run `yarn link` inside `modules/repay-scripts`
4. Go over to Cactus and run `yarn link @repay/babel-preset`, followed by `yarn link @repay/scripts`
5. Run `yarn w standard start`
6. Open up the app in IE11 in BrowserStack to make sure that it loads/works