### PR TITLE
Upgrade @repay/scripts and @repay/eslint-config in @repay/create-ui

### DIFF
--- a/modules/create-repay-ui/_templates/templates/javascript/packagejson.ejs.t
+++ b/modules/create-repay-ui/_templates/templates/javascript/packagejson.ejs.t
@@ -19,7 +19,7 @@ to: <%=directory%>/<%=name%>/package.json
     "react-dom": "^16.13.1"
   },
   "devDependencies": {
-    "@repay/eslint-config": "^2.0.0",
+    "@repay/eslint-config": "^3.0.0",
     "eslint": "^7.4.0",
     "@repay/scripts": "^2.0.0",
     "prettier": "^2.0.5"

--- a/modules/create-repay-ui/_templates/templates/javascript/packagejson.ejs.t
+++ b/modules/create-repay-ui/_templates/templates/javascript/packagejson.ejs.t
@@ -21,7 +21,7 @@ to: <%=directory%>/<%=name%>/package.json
   "devDependencies": {
     "@repay/eslint-config": "^2.0.0",
     "eslint": "^7.4.0",
-    "@repay/scripts": "1.0.0",
+    "@repay/scripts": "^2.0.0",
     "prettier": "^2.0.5"
   }
 }

--- a/modules/create-repay-ui/_templates/templates/typescript/packagejson.ejs.t
+++ b/modules/create-repay-ui/_templates/templates/typescript/packagejson.ejs.t
@@ -25,7 +25,7 @@ to: <%=directory%>/<%=name%>/package.json
     "@types/react-dom": "^16.9.2",
     "typescript": "^3.7.2",
     "@typescript-eslint/parser": "^3.6.0",
-    "@repay/eslint-config": "^2.0.0",
+    "@repay/eslint-config": "^3.0.0",
     "eslint": "^7.4.0",
     "@repay/scripts": "^2.0.0",
     "prettier": "^2.0.5"

--- a/modules/create-repay-ui/_templates/templates/typescript/packagejson.ejs.t
+++ b/modules/create-repay-ui/_templates/templates/typescript/packagejson.ejs.t
@@ -27,7 +27,7 @@ to: <%=directory%>/<%=name%>/package.json
     "@typescript-eslint/parser": "^3.6.0",
     "@repay/eslint-config": "^2.0.0",
     "eslint": "^7.4.0",
-    "@repay/scripts": "1.0.0",
+    "@repay/scripts": "^2.0.0",
     "prettier": "^2.0.5"
   }
 }


### PR DESCRIPTION
Just want to make sure we keep up-to-date with the newly released `@repay/scripts` and `@repay/eslint-config`.  To test, ensure that `create-repay-ui`, that `yarn why @repay/scripts` spits out v2.0.0 inside your generated project folder, and that `yarn why @repay/eslint-config` spits out v3.0.0.