### PR TITLE
CACTUS-281 :: TypeScript Linting

### DIFF
--- a/modules/eslint-config/README.md
+++ b/modules/eslint-config/README.md
@@ -6,9 +6,9 @@ The eslint-config used at REPAY.
 
 To use this configuration you will need to follow three steps:
 
-1. install this package via your package manager of choice  
+1. install this package via your package manager of choice
    `yarn add -D @repay/eslint-config eslint`
-1. install the peer dependencies and configurations  
+1. install the peer dependencies and configurations
    `yarn repay-eslint install`
 
 To run the linter you should add a "script" to the root `package.json` such as:
@@ -23,6 +23,36 @@ To run the linter you should add a "script" to the root `package.json` such as:
 ```
 
 You will then be able to run the linter using the command: `yarn lint`. Adding the `--fix` argument will auto fix any issues which can be listed as `yarn fmt` above.
+
+## Configuring .eslintrc
+
+You may want to extend from `@repay/eslint-config` in your project's `.eslintrc` file so that you can make project-specific adjustments.
+
+### JS Project
+
+```
+// .eslintrc
+{
+  "extends": ["@repay/eslint-config"],
+  "overrides": [{
+    // override any linting rules here
+  }]
+}
+```
+
+### TS Project
+
+```
+// .eslintrc
+{
+  "extends": ["@repay/eslint-config/ts"],
+  "overrides": [{
+    // override any linting rules here
+  }]
+}
+```
+
+If you are configuring this eslint in a TypeScript project, we recommend that you follow the `typescript-eslint` guidelines for linting with type information found [here](https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/TYPED_LINTING.md).
 
 ## Design Principles
 

--- a/modules/eslint-config/package.json
+++ b/modules/eslint-config/package.json
@@ -9,6 +9,7 @@
   "files": [
     "cli.js",
     "index.js",
+    "ts.js",
     "*.template"
   ],
   "repository": "https://github.com/repaygithub/ui-tools/tree/master/modules/eslint-config",
@@ -22,6 +23,8 @@
     "test": "yarn lint"
   },
   "dependencies": {
+    "@typescript-eslint/eslint-plugin": "^3.7.1",
+    "@typescript-eslint/parser": "^3.7.1",
     "babel-eslint": "^10.1.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-config-react": "^1.1.7",

--- a/modules/eslint-config/ts.js
+++ b/modules/eslint-config/ts.js
@@ -1,0 +1,48 @@
+// Typescript Eslint Config
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+  settings: {
+    react: {
+      version: '>=16.8.3',
+    },
+  },
+  plugins: ['@typescript-eslint', 'prettier', 'react', 'react-hooks', 'simple-import-sort'],
+  extends: [
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react/recommended',
+    'prettier/@typescript-eslint',
+  ],
+  rules: {
+    'no-unused-vars': ['error', { vars: 'all', args: 'after-used', ignoreRestSiblings: true }],
+    'no-undef': 'error',
+    'constructor-super': 'error',
+    'no-this-before-super': 'error',
+    'no-duplicate-case': 'error',
+    'no-dupe-keys': 'error',
+    'no-func-assign': 'error',
+    'no-sparse-arrays': 'error',
+    'no-unsafe-negation': 'error',
+    'no-unreachable': 'error',
+    'valid-typeof': 'error',
+    'react/jsx-uses-react': 'error',
+    'react/jsx-uses-vars': 'error',
+    'react/jsx-no-undef': 'error',
+    'react/jsx-curly-brace-presence': ['error', { props: 'never', children: 'ignore' }],
+    'react/no-string-refs': 'error',
+    'react/no-direct-mutation-state': 'error',
+    'react/react-in-jsx-scope': 'error',
+    'react/require-render-return': 'error',
+    'react/jsx-no-duplicate-props': 'error',
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
+    'simple-import-sort/sort': 'error',
+  },
+}

--- a/modules/eslint-config/ts.js
+++ b/modules/eslint-config/ts.js
@@ -17,11 +17,21 @@ module.exports = {
   plugins: ['@typescript-eslint', 'prettier', 'react', 'react-hooks', 'simple-import-sort'],
   extends: [
     'plugin:@typescript-eslint/recommended',
-    'plugin:react/recommended',
+    'prettier/react',
     'prettier/@typescript-eslint',
   ],
+  env: {
+    es6: true,
+    node: true,
+    browser: true,
+    commonjs: true,
+    jest: true,
+  },
   rules: {
-    'no-unused-vars': ['error', { vars: 'all', args: 'after-used', ignoreRestSiblings: true }],
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { vars: 'all', args: 'after-used', ignoreRestSiblings: true },
+    ],
     'no-undef': 'error',
     'constructor-super': 'error',
     'no-this-before-super': 'error',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1397,8 +1397,10 @@
     read-package-json-fast "^1.1.3"
 
 "@repay/eslint-config@./modules/eslint-config":
-  version "2.1.0"
+  version "3.0.0"
   dependencies:
+    "@typescript-eslint/eslint-plugin" "^3.7.1"
+    "@typescript-eslint/parser" "^3.7.1"
     babel-eslint "^10.1.0"
     eslint-config-prettier "^6.11.0"
     eslint-config-react "^1.1.7"
@@ -1490,6 +1492,11 @@
   resolved "https://registry.yarnpkg.com/@types/error-stack-parser/-/error-stack-parser-1.3.18.tgz#e01c9f8c85ca83b610320c62258b0c9026ade0f7"
   integrity sha1-4ByfjIXKg7YQMgxiJYsMkCat4Pc=
 
+"@types/eslint-visitor-keys@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
+  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
 "@types/estree@0.0.39", "@types/estree@^0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -1545,6 +1552,11 @@
   dependencies:
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
+
+"@types/json-schema@^7.0.3":
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
+  integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
 "@types/json-schema@^7.0.4":
   version "7.0.4"
@@ -1649,6 +1661,66 @@
   integrity sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
   dependencies:
     "@types/node" "*"
+
+"@typescript-eslint/eslint-plugin@^3.7.1":
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.7.1.tgz#d144c49a9a0ffe8dd704bb179c243df76c111bc9"
+  integrity sha512-3DB9JDYkMrc8Au00rGFiJLK2Ja9CoMP6Ut0sHsXp3ZtSugjNxvSSHTnKLfo4o+QmjYBJqEznDqsG1zj4F2xnsg==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "3.7.1"
+    debug "^4.1.1"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^3.0.0"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/experimental-utils@3.7.1":
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.7.1.tgz#ab036caaed4c870d22531d41f9352f3147364d61"
+  integrity sha512-TqE97pv7HrqWcGJbLbZt1v59tcqsSVpWTOf1AqrWK7n8nok2sGgVtYRuGXeNeLw3wXlLEbY1MKP3saB2HsO/Ng==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/types" "3.7.1"
+    "@typescript-eslint/typescript-estree" "3.7.1"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
+"@typescript-eslint/parser@^3.7.1":
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-3.7.1.tgz#5d9ccecb116d12d9c6073e9861c57c9b1aa88128"
+  integrity sha512-W4QV/gXvfIsccN8225784LNOorcm7ch68Fi3V4Wg7gmkWSQRKevO4RrRqWo6N/Z/myK1QAiGgeaXN57m+R/8iQ==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "3.7.1"
+    "@typescript-eslint/types" "3.7.1"
+    "@typescript-eslint/typescript-estree" "3.7.1"
+    eslint-visitor-keys "^1.1.0"
+
+"@typescript-eslint/types@3.7.1":
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.7.1.tgz#90375606b2fd73c1224fe9e397ee151e28fa1e0c"
+  integrity sha512-PZe8twm5Z4b61jt7GAQDor6KiMhgPgf4XmUb9zdrwTbgtC/Sj29gXP1dws9yEn4+aJeyXrjsD9XN7AWFhmnUfg==
+
+"@typescript-eslint/typescript-estree@3.7.1":
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.7.1.tgz#ce1ffbd0fa53f34d4ce851a7a364e392432f6eb3"
+  integrity sha512-m97vNZkI08dunYOr2lVZOHoyfpqRs0KDpd6qkGaIcLGhQ2WPtgHOd/eVbsJZ0VYCQvupKrObAGTOvk3tfpybYA==
+  dependencies:
+    "@typescript-eslint/types" "3.7.1"
+    "@typescript-eslint/visitor-keys" "3.7.1"
+    debug "^4.1.1"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/visitor-keys@3.7.1":
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.7.1.tgz#b90191e74efdee656be8c5a30f428ed16dda46d1"
+  integrity sha512-xn22sQbEya+Utj2IqJHGLA3i1jDzR43RzWupxojbSWnj3nnPLavaQmWe5utw03CwYao3r00qzXfgJMGNkrzrAA==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -4860,7 +4932,7 @@ eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-scope@^5.1.0:
+eslint-scope@^5.0.0, eslint-scope@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.0.tgz#d0f971dfe59c69e0cada684b23d49dbf82600ce5"
   integrity sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==
@@ -9463,7 +9535,7 @@ regexp.prototype.flags@^1.3.0:
     define-properties "^1.1.3"
     es-abstract "^1.17.0-next.1"
 
-regexpp@^3.1.0:
+regexpp@^3.0.0, regexpp@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
@@ -11226,7 +11298,7 @@ truncate-utf8-bytes@^1.0.0:
   dependencies:
     utf8-byte-length "^1.0.1"
 
-tslib@^1.10.0:
+tslib@^1.10.0, tslib@^1.8.1:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
@@ -11235,6 +11307,13 @@ tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+tsutils@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
+  integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  dependencies:
+    tslib "^1.8.1"
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-281

This is my first time ever setting up an eslint config, so please let me know if there's anything I'm doing here that's just outright wrong. I kind of just fiddled around until I was able to get something working so 🤷 

I copied the rules from the JS config into the TS one because I figured we still probably want to enforce those, but I'm open to suggestions if there's anything anyone would like to change there.

## Testing

I recommend using a tool like Yalc (https://www.npmjs.com/package/yalc) to test this.

1. Check out this branch and run `yarn install`
2. Run `yalc publish` in `modules/eslint-config`
3. In cactus, run `yalc add --dev @repay/eslint-config`
4. In `package.json` at the root of cactus, add `.yalc/*` and `.yalc/@*/*` to the `packages` array under `workspaces`.
5. In `.eslintrc` at the root of cactus, set `extends` to `["@repay/eslint-config/ts"]`.
6. Run `yarn install` in cactus.
7. Run `yarn lint` at the root.

If done correctly, you will see some 3000 problems show up from the linting. As long as the linter is able to find the `/ts` config, I wouldn't be too worried about that. I'm going to be working on a follow up PR in cactus to use the TS config and I'll have to get those errors resolved.