### PR TITLE
CACTUS-318 :: add _templates folder to published package for @repay/create-ui

### DIFF
--- a/modules/create-repay-ui/package.json
+++ b/modules/create-repay-ui/package.json
@@ -11,7 +11,8 @@
   },
   "files": [
     "bin/",
-    "src/"
+    "src/",
+    "_templates"
   ],
   "publishConfig": {
     "registry": "https://registry.yarnpkg.com"


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-318

### Testing

Testing is a bit hard, because this bug didn't show up using a linked package.  But you could do the following.

1. `cd` into `./modules/create-repay-ui`
2. Run `yalc publish` (if you have yalc https://www.npmjs.com/package/yalc)
3. Run `yarn global add ~/.yalc/packages/@repay/create-ui/0.0.2`
4. Run `create-repay-ui` and make sure that it works