### PR TITLE
create-repay-ui updates

### DIFF
--- a/modules/create-repay-ui/_templates/templates/javascript/home.ejs.t
+++ b/modules/create-repay-ui/_templates/templates/javascript/home.ejs.t
@@ -1,14 +1,23 @@
 ---
 to: <%=directory%>/<%=name%>/src/components/Home.jsx
 ---
-import { Link } from '@reach/router'
+import { Link as RouterLink } from '@reach/router'
+import { Card, Flex, Link, Text } from '@repay/cactus-web'
 import React from 'react'
 
 const Home = () => {
   return (
     <div>
       <h1>This is the Home Page</h1>
-      <Link to="/users">Users page</Link>
+      <Flex justifyContent="flex-start">
+        <Card margin="40px">
+          <Text as="h4">This is some text in a card</Text>
+          <Text>Here are some links:</Text>
+          <Link as={RouterLink} to="/users">
+            Users page
+          </Link>
+        </Card>
+      </Flex>
     </div>
   )
 }

--- a/modules/create-repay-ui/_templates/templates/javascript/packagejson.ejs.t
+++ b/modules/create-repay-ui/_templates/templates/javascript/packagejson.ejs.t
@@ -16,25 +16,27 @@ to: <%=directory%>/<%=name%>/package.json
   "keywords": [],
   "license": "MIT",
   "dependencies": {
-    "@reach/router": "1.3.4",
+    "@reach/router": "^1.3.4",
+    "@repay/cactus-web": "^1.1.2",
+    "axios": "^0.19.2",
+    "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "axios": "^0.19.2",
-    "@repay/cactus-web": "^1.1.2"
+    "react-is": "^16.13.1",
+    "styled-components": "^5.1.1"
   },
   "devDependencies": {
-    "@babel/core": "7.11.1",
-    "@repay/babel-preset": "1.0.0",
+    "@babel/core": "^7.11.1",
+    "@repay/babel-preset": "^1.0.0",
     "@repay/eslint-config": "^3.0.0",
     "@repay/scripts": "^2.0.0",
     "@testing-library/jest-dom": "^5.11.2",
     "@testing-library/react": "^10.4.3",
-    "babel-jest": "26.2.2",
+    "babel-jest": "^26.3.0",
     "eslint": "^7.6.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.2.2",
-    "jest-raw-loader": "1.0.1",
-    "prettier": "^2.0.5",
-    "styled-components": "^4.4.1"
+    "jest-raw-loader": "^1.0.1",
+    "prettier": "^2.0.5"
   }
 }

--- a/modules/create-repay-ui/_templates/templates/shared/app.ejs.t
+++ b/modules/create-repay-ui/_templates/templates/shared/app.ejs.t
@@ -2,18 +2,17 @@
 to: "<%=directory%>/<%=name%>/src/<%=type === 'typescript' ? 'App.tsx' : 'App.jsx' %>"
 ---
 import { Router } from '@reach/router'
-import { StyleProvider } from '@repay/cactus-web'
+import { Spinner, StyleProvider } from '@repay/cactus-web'
 import React, { lazy, Suspense } from 'react'
 
 import Layout from './components/Layout'
-import Loading from './components/Loading'
 
 const LazyHome = lazy(() => import('./components/Home'))
 const LazyUsers = lazy(() => import('./components/Users'))
 
 const App = () => (
-  <StyleProvider>
-    <Suspense fallback={<Loading />}>
+  <StyleProvider global>
+    <Suspense fallback={<Spinner />}>
       <Layout>
         <Router>
           <LazyUsers path="users" />

--- a/modules/create-repay-ui/_templates/templates/shared/loading.ejs.t
+++ b/modules/create-repay-ui/_templates/templates/shared/loading.ejs.t
@@ -1,8 +1,0 @@
----
-to: "<%=directory%>/<%=name%>/src/components/<%=type === 'typescript' ? 'Loading.tsx' : 'Loading.jsx' %>"
----
-import React from 'react'
-
-const Loading = () => <div>Loading...</div>
-
-export default Loading

--- a/modules/create-repay-ui/_templates/templates/typescript/home.ejs.t
+++ b/modules/create-repay-ui/_templates/templates/typescript/home.ejs.t
@@ -1,15 +1,23 @@
 ---
 to: <%=directory%>/<%=name%>/src/components/Home.tsx
 ---
-import { Link } from '@reach/router'
-import { RouteComponentProps } from '@reach/router'
+import { Link as RouterLink, RouteComponentProps } from '@reach/router'
+import { Card, Flex, Link, Text } from '@repay/cactus-web'
 import React from 'react'
 
 const Home: React.FC<RouteComponentProps> = () => {
   return (
     <div>
       <h1>This is the Home Page</h1>
-      <Link to="/users">Users page</Link>
+      <Flex justifyContent="flex-start">
+        <Card margin="40px">
+          <Text as="h4">This is some text in a card</Text>
+          <Text>Here are some links:</Text>
+          <Link as={RouterLink} to="/users">
+            Users page
+          </Link>
+        </Card>
+      </Flex>
     </div>
   )
 }

--- a/modules/create-repay-ui/_templates/templates/typescript/packagejson.ejs.t
+++ b/modules/create-repay-ui/_templates/templates/typescript/packagejson.ejs.t
@@ -17,15 +17,18 @@ to: <%=directory%>/<%=name%>/package.json
   "keywords": [],
   "license": "MIT",
   "dependencies": {
-    "@reach/router": "1.3.4",
+    "@reach/router": "^1.3.4",
+    "@repay/cactus-web": "^1.1.2",
+    "axios": "^0.19.2",
+    "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "axios": "^0.19.2",
-    "@repay/cactus-web": "^1.1.2"
+    "react-is": "^16.13.1",
+    "styled-components": "^5.1.1"
   },
   "devDependencies": {
-    "@babel/core": "7.11.1",
-    "@repay/babel-preset": "1.0.0",
+    "@babel/core": "^7.11.1",
+    "@repay/babel-preset": "^1.0.0",
     "@repay/eslint-config": "^3.0.0",
     "@repay/scripts": "^2.0.0",
     "@testing-library/jest-dom": "^5.11.2",
@@ -33,14 +36,15 @@ to: <%=directory%>/<%=name%>/package.json
     "@types/reach__router": "^1.3.5",
     "@types/react": "^16.9.5",
     "@types/react-dom": "^16.9.2",
+    "@types/styled-components": "^5.1.2",
+    "@types/styled-system": "^5.1.10",
     "@typescript-eslint/parser": "^3.6.0",
-    "babel-jest": "26.2.2",
+    "babel-jest": "^26.3.0",
     "eslint": "^7.6.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.2.2",
-    "jest-raw-loader": "1.0.1",
+    "jest-raw-loader": "^1.0.1",
     "prettier": "^2.0.5",
-    "styled-components": "^4.4.1",
     "typescript": "^3.7.2"
   }
 }


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-322

Mostly just fixing some issues with the dependencies (i.e. missing peer dependencies and dev dependencies that should be regular dependencies) and making use of some Cactus components on the Home page.

### Testing

1. `cd ./modules/create-repay-ui` and run `yalc publish`
2. Go to some other folder.  Run `yarn global add ~/.yalc/packages/@repay/create-ui/0.0.3`
3. Run `create-repay-ui testing`.  Select JS or TS and create an app
4. `cd` into your generated app.  Make sure `yarn test`, `yarn lint`, and `yarn test:types` (if applicable) all work.
5. Run `yarn start` to run the app.  Make sure everything looks good.