### PR TITLE
Upgrade @repay/cactus-web to v2

### DIFF
--- a/modules/create-repay-ui/_templates/templates/javascript/packagejson.ejs.t
+++ b/modules/create-repay-ui/_templates/templates/javascript/packagejson.ejs.t
@@ -17,7 +17,7 @@ to: <%=directory%>/<%=name%>/package.json
   "license": "MIT",
   "dependencies": {
     "@reach/router": "^1.3.4",
-    "@repay/cactus-web": "^1.1.2",
+    "@repay/cactus-web": "^2.0.0",
     "axios": "^0.19.2",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",

--- a/modules/create-repay-ui/_templates/templates/typescript/packagejson.ejs.t
+++ b/modules/create-repay-ui/_templates/templates/typescript/packagejson.ejs.t
@@ -18,7 +18,7 @@ to: <%=directory%>/<%=name%>/package.json
   "license": "MIT",
   "dependencies": {
     "@reach/router": "^1.3.4",
-    "@repay/cactus-web": "^1.1.2",
+    "@repay/cactus-web": "^2.0.0",
     "axios": "^0.19.2",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",


### PR DESCRIPTION
### Testing

1. Pull down branch.
2. `cd` into `modules/create-repay-ui` and run `yalc publish`
3. Run `yarn global add ~/.yalc/packages/@repay/create-ui/0.1.0` to install the executable from the yalc version
4. Run `create-repay-ui` twice...once for JS and once for TS.  Ensure that `@repay/cactus-web` is on v2.0.0 for both versions.
5. Check that the app runs okay with `yarn start`.