### PR TITLE
feat(eslint-config): add --ts option to eslint-config. Generate that …

### DIFF
--- a/modules/create-repay-ui/_templates/templates/shared/app.ejs.t
+++ b/modules/create-repay-ui/_templates/templates/shared/app.ejs.t
@@ -10,7 +10,7 @@ import AppLayout from './components/AppLayout'
 const LazyHome = lazy(() => import('./components/Home'))
 const LazyUsers = lazy(() => import('./components/Users'))
 
-const App = () => (
+const App<%= type === 'typescript' ? ': React.FC' : '' %> = () => (
   <StyleProvider global>
     <Router>
       <AppLayout>

--- a/modules/create-repay-ui/_templates/templates/typescript/api.ejs.t
+++ b/modules/create-repay-ui/_templates/templates/typescript/api.ejs.t
@@ -2,7 +2,7 @@
 to: <%=directory%>/<%=name%>/src/helpers/api.ts
 ---
 
-import axios from 'axios'
+import axios, { AxiosResponse } from 'axios'
 
 const BASE_URL = 'https://www.repay.com'
 
@@ -21,11 +21,15 @@ const apiClient = axios.create({
 // To add extra logic to each request and/or response, use
 // axios incerceptors https://github.com/axios/axios#interceptors
 
-export const getUsers = async () => apiClient.get('/users')
+export const getUsers = async (): Promise<AxiosResponse<unknown>> => apiClient.get('/users')
 
-export const getUser = async (userId: string) => apiClient.get(`/users/${userId}`)
+export const getUser = async (userId: string): Promise<AxiosResponse<unknown>> =>
+  apiClient.get(`/users/${userId}`)
 
-export const createUser = async (newUser: User) => apiClient.post('/users', newUser)
+export const createUser = async (newUser: User): Promise<AxiosResponse<unknown>> =>
+  apiClient.post('/users', newUser)
 
-export const updateUser = async (userId: string, updatedUser: User) =>
-  apiClient.put(`/users/${userId}`, updatedUser)
+export const updateUser = async (
+  userId: string,
+  updatedUser: User
+): Promise<AxiosResponse<unknown>> => apiClient.put(`/users/${userId}`, updatedUser)

--- a/modules/create-repay-ui/_templates/templates/typescript/layout.ejs.t
+++ b/modules/create-repay-ui/_templates/templates/typescript/layout.ejs.t
@@ -17,8 +17,8 @@ const AppLayout: React.FunctionComponent<AppLayoutProps> = ({ children }) => {
   return (
     <Layout>
       <BrandBar userMenuText="Hershell Jewess" logo={LOGO}>
-        <BrandBar.UserMenuItem onSelect={() => {}}>Settings</BrandBar.UserMenuItem>
-        <BrandBar.UserMenuItem onSelect={() => {}}>Logout</BrandBar.UserMenuItem>
+        <BrandBar.UserMenuItem onSelect={() => undefined}>Settings</BrandBar.UserMenuItem>
+        <BrandBar.UserMenuItem onSelect={() => undefined}>Logout</BrandBar.UserMenuItem>
       </BrandBar>
       <MenuBar>
         <MenuBar.Item as={Link} to="/">

--- a/modules/create-repay-ui/src/main.js
+++ b/modules/create-repay-ui/src/main.js
@@ -51,9 +51,17 @@ export async function createProject(options) {
     {
       title: 'Initialize eslint config and dependencies',
       task: async () =>
-        await execa('yarn', ['repay-eslint', 'install'], {
-          cwd: options.targetDirectory,
-        }),
+        await execa(
+          'yarn',
+          [
+            'repay-eslint',
+            'install',
+            `${options.template.toLowerCase() === 'typescript' && '--ts'}`,
+          ],
+          {
+            cwd: options.targetDirectory,
+          }
+        ),
     },
   ])
 

--- a/modules/eslint-config/.eslintrcts.template
+++ b/modules/eslint-config/.eslintrcts.template
@@ -1,0 +1,9 @@
+{
+  "extends": ["@repay/eslint-config"],
+  "overrides": [
+    {
+      "files": ["**/*.{ts,tsx}"],
+      "extends": ["@repay/eslint-config/ts"]
+    }
+  ]
+}

--- a/modules/eslint-config/cli.js
+++ b/modules/eslint-config/cli.js
@@ -11,7 +11,9 @@ let filesExisting = false
 
 if (args.includes('install')) {
   // add .eslintrc
-  const eslintConfig = fs.readFileSync(path.join(__dirname, './.eslintrc.template'))
+  const eslintConfig = args.includes('--ts')
+    ? fs.readFileSync(path.join(__dirname, './.eslintrcts.template'))
+    : fs.readFileSync(path.join(__dirname, './.eslintrc.template'))
   const eslintPath = path.join(cwd, '.eslintrc')
   if (isForce || !fs.existsSync(eslintPath)) {
     fs.writeFileSync(eslintPath, eslintConfig)


### PR DESCRIPTION
…file in ts option for crate-ui

To test:
 -Navigate to the eslint-config folder
 -`yalc publish`, this will give you a _`<version-number>`_ in the console
 -`yarn global add ~/.yalc/packages/@repay/eslint-config/<version-number>`
 -Navigate to another directory and run `repay-eslint install --ts`
 -Check that the generated ._eslintrc_ file matches the expected one.

PS: For the generated app from _create-repay-ui_,  we'll have to wait for the _eslint-config_ to be published in order for it to be available. I already tried running the _create-repay-ui_ CLI locally and it generates the correct file.

[CACTUS-323]

[CACTUS-323]: https://repayonline.atlassian.net/browse/CACTUS-323