### PR TITLE
CACTUS-291 :: Add coverage support for SonarQube

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.log
 **/dist
 **/coverage
+**/test-report.xml
 .cache
 .DS_Store
 

--- a/modules/testing-tools/package.json
+++ b/modules/testing-tools/package.json
@@ -22,9 +22,12 @@
     ],
     "collectCoverageFrom": [
       "src/**/*.js"
-    ]
+    ],
+    "testResultsProcessor": "jest-sonar-reporter"
   },
   "devDependencies": {
+    "jest": "^26.5.2",
+    "jest-sonar-reporter": "^2.0.0",
     "testcafe": "^1.9.4"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "fmt": "yarn lint --fix",
     "test": "yarn lint && yarn ws run test",
     "test:ci": "yarn test",
+    "test:sonar": "yarn w @repay/testing-tools test --coverage",
     "commit": "git-cz",
     "release": "yarn install --registry https://registry.yarnpkg.com && lerna publish --no-private --registry https://registry.yarnpkg.com"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2172,7 +2172,7 @@
     "@types/node" ">= 8"
 
 "@repay/eslint-config@./modules/eslint-config":
-  version "3.1.1"
+  version "3.2.0"
   dependencies:
     "@typescript-eslint/eslint-plugin" "^4.4.0"
     "@typescript-eslint/parser" "^4.4.0"
@@ -8570,6 +8570,13 @@ jest-snapshot@^26.5.2:
     pretty-format "^26.5.2"
     semver "^7.3.2"
 
+jest-sonar-reporter@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/jest-sonar-reporter/-/jest-sonar-reporter-2.0.0.tgz#faa54a7d2af7198767ee246a82b78c576789cf08"
+  integrity sha512-ZervDCgEX5gdUbdtWsjdipLN3bKJwpxbvhkYNXTAYvAckCihobSLr9OT/IuyNIRT1EZMDDwR6DroWtrq+IL64w==
+  dependencies:
+    xml "^1.0.1"
+
 jest-util@^26.5.2:
   version "26.5.2"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.5.2.tgz#8403f75677902cc52a1b2140f568e91f8ed4f4d7"
@@ -14030,6 +14037,11 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-291

This is essentially the same thing as https://github.com/repaygithub/cactus/pull/418.  The difference is that I only included one package.  Unit tests don't really make sense for `babel-preset`, `create-repay-ui`, and `eslint-config`, while the tests for `repay-scripts` actually run the tool using `yarn`, so it doesn't actually register test coverage.  Maybe we can find a way to analyze coverage for that package later, but now is not that time.

So that means that only `testing-tools` is really getting analyzed here.  As with the Cactus version, I would just go to the ui-tools project in SonarQube and make sure that coverage is correctly captured. See https://sonarqube.repay.ninja/dashboard?id=ui-tools (you need to be on the VPN)