### PR TITLE
CACTUS-292 :: BlackDuck Setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test:ci": "yarn test",
     "test:sonar": "yarn w @repay/testing-tools test --coverage",
     "commit": "git-cz",
-    "release": "npm login && yarn install --registry https://registry.yarnpkg.com && lerna publish --no-private --registry https://registry.yarnpkg.com"
+    "release": "npm login && yarn install --registry https://registry.yarnpkg.com && lerna publish --no-private --registry https://registry.yarnpkg.com",
+    "scan:blackduck": "bash scripts/blackduck.sh babel-preset && bash scripts/blackduck.sh create-repay-ui && bash scripts/blackduck.sh eslint-config && bash scripts/blackduck.sh repay-scripts && bash scripts/blackduck.sh testing-tools"
   },
   "devDependencies": {
     "@repay/eslint-config": "./modules/eslint-config",

--- a/scripts/blackduck.sh
+++ b/scripts/blackduck.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -eo pipefail
+
+bash <(curl -s -L https://detect.synopsys.com/detect.sh) \
+    --detect.source.path="${WORKSPACE}/ui-tools/modules/$1" \
+    --detect.yarn.prod.only=true \
+    --detect.project.name="github.com/repaygithub/ui-tools" \
+    --detect.project.version.name="master" \
+    --detect.code.location.name="ui-tools" \
+    --detect.project.version.phase="RELEASED" \
+    --blackduck.url="https://repay.blackducksoftware.com" \
+    --blackduck.api.token=${BLACKDUCK_TOKEN} \
+    --detect.project.version.distribution=SAAS \
+    --detect.cleanup=true \
+    --detect.tools.excluded=SIGNATURE_SCAN \
+    --detect.excluded.detector.types=MAVEN


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-292

This is PR number two for BlackDuck. It's pretty much exactly the same as the cactus PR.

If you want to test, you can trigger the Jenkins job [here](https://jenkins.internal.repay.ninja/blue/organizations/jenkins/ui-blackduck/activity) and you can view the project and the scan results [here](https://repay.blackducksoftware.com/api/projects/46268be4-1568-41d5-b8cb-2095e7956189/versions/1e219621-38d4-4c3b-b945-a27c5e34b1d3/components?sort=projectName%20ASC&offset=0&limit=100&filter=bomInclusion%3Afalse&filter=bomMatchReviewStatus%3AREVIEWED). You will have to be on the VPN to access those links.