### PR TITLE
chore(create-repay-ui): upgrade cactus packages and fix braking changes

### DIFF
--- a/modules/create-repay-ui/_templates/templates/javascript/layout.ejs.t
+++ b/modules/create-repay-ui/_templates/templates/javascript/layout.ejs.t
@@ -12,9 +12,15 @@ const LOGO =
 const AppLayout = ({ children }) => {
   return (
     <Layout>
-      <BrandBar userMenuText="Hershell Jewess" logo={LOGO}>
-        <BrandBar.UserMenuItem onSelect={() => {}}>Settings</BrandBar.UserMenuItem>
-        <BrandBar.UserMenuItem onSelect={() => {}}>Logout</BrandBar.UserMenuItem>
+     <BrandBar logo={LOGO}>
+        <BrandBar.UserMenu label="Hershell Jewess">
+          <BrandBar.UserMenuItem onSelect={() => undefined}>
+            Settings
+          </BrandBar.UserMenuItem>
+          <BrandBar.UserMenuItem onSelect={() => undefined}>
+            Logout
+          </BrandBar.UserMenuItem>
+        </BrandBar.UserMenu>
       </BrandBar>
       <MenuBar>
         <MenuBar.Item as={Link} to="/">

--- a/modules/create-repay-ui/_templates/templates/javascript/packagejson.ejs.t
+++ b/modules/create-repay-ui/_templates/templates/javascript/packagejson.ejs.t
@@ -16,7 +16,7 @@ to: <%=directory%>/<%=name%>/package.json
   "keywords": [],
   "license": "MIT",
   "dependencies": {
-    "@repay/cactus-web": "^3.1.0",
+    "@repay/cactus-web": "^4.3.0",
     "react-router-dom": "^5.2.0",
     "axios": "^0.20.0",
     "prop-types": "^15.7.2",
@@ -27,9 +27,9 @@ to: <%=directory%>/<%=name%>/package.json
   },
   "devDependencies": {
     "@babel/core": "^7.11.1",
-    "@repay/babel-preset": "^1.0.0",
-    "@repay/eslint-config": "^3.0.0",
-    "@repay/scripts": "^2.0.0",
+    "@repay/babel-preset": "^1.0.1",
+    "@repay/eslint-config": "^3.2.0",
+    "@repay/scripts": "^2.0.1",
     "@testing-library/jest-dom": "^5.11.2",
     "@testing-library/react": "^11.0.4",
     "babel-jest": "^26.3.0",

--- a/modules/create-repay-ui/_templates/templates/typescript/layout.ejs.t
+++ b/modules/create-repay-ui/_templates/templates/typescript/layout.ejs.t
@@ -16,10 +16,16 @@ interface AppLayoutProps {
 const AppLayout: React.FunctionComponent<AppLayoutProps> = ({ children }) => {
   return (
     <Layout>
-      <BrandBar userMenuText="Hershell Jewess" logo={LOGO}>
-        <BrandBar.UserMenuItem onSelect={() => undefined}>Settings</BrandBar.UserMenuItem>
-        <BrandBar.UserMenuItem onSelect={() => undefined}>Logout</BrandBar.UserMenuItem>
-      </BrandBar>
+      <BrandBar logo={LOGO}>
+          <BrandBar.UserMenu label="Hershell Jewess">
+            <BrandBar.UserMenuItem onSelect={() => undefined}>
+              Settings
+            </BrandBar.UserMenuItem>
+            <BrandBar.UserMenuItem onSelect={() => undefined}>
+              Logout
+            </BrandBar.UserMenuItem>
+          </BrandBar.UserMenu>
+        </BrandBar>
       <MenuBar>
         <MenuBar.Item as={Link} to="/">
           Home Page

--- a/modules/create-repay-ui/_templates/templates/typescript/packagejson.ejs.t
+++ b/modules/create-repay-ui/_templates/templates/typescript/packagejson.ejs.t
@@ -17,7 +17,7 @@ to: <%=directory%>/<%=name%>/package.json
   "keywords": [],
   "license": "MIT",
   "dependencies": {
-    "@repay/cactus-web": "^3.1.0",
+    "@repay/cactus-web": "^4.3.0",
     "react-router-dom": "^5.2.0",
     "axios": "^0.20.0",
     "prop-types": "^15.7.2",
@@ -28,9 +28,9 @@ to: <%=directory%>/<%=name%>/package.json
   },
   "devDependencies": {
     "@babel/core": "^7.11.1",
-    "@repay/babel-preset": "^1.0.0",
-    "@repay/eslint-config": "^3.0.0",
-    "@repay/scripts": "^2.0.0",
+    "@repay/babel-preset": "^1.0.1",
+    "@repay/eslint-config": "^3.2.0",
+    "@repay/scripts": "^2.0.1",
     "@testing-library/jest-dom": "^5.11.2",
     "@testing-library/react": "^11.0.4",
     "@types/react": "^16.9.5",


### PR DESCRIPTION
Generate a new app. Check that the generated code has the latest cactus packages and that the BrandBar braking change has been addressed

[CACTUS-453]

[CACTUS-453]: https://repayonline.atlassian.net/browse/CACTUS-453