### PR TITLE
Fix create-repay-ui test directory structure

### DIFF
--- a/modules/create-repay-ui/_templates/templates/shared/example-test.ejs.t
+++ b/modules/create-repay-ui/_templates/templates/shared/example-test.ejs.t
@@ -1,12 +1,12 @@
 ---
-to: "<%=directory%>/<%=name%>/tests/<%=type === 'typescript' ? 'Home.test.tsx' : 'Home.test.jsx' %>"
+to: "<%=directory%>/<%=name%>/src/tests/<%=type === 'typescript' ? 'Home.test.tsx' : 'Home.test.jsx' %>"
 ---
 import { StyleProvider } from '@repay/cactus-web'
 import { render } from '@testing-library/react'
 import * as React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 
-import Home from '../src/components/Home'
+import Home from '../components/Home'
 
 describe('Test case 1', () => {
   test('Home page text is visible', () => {


### PR DESCRIPTION
The unit test file was in a separate directory from the test setup (we had two separate `tests` directories).  This fixes that.

### Testing

1. Pull this down, `cd` into `modules/create-repay-ui`, and run `yalc publish`.
2. Run `yarn global add ~/.yalc/packages/@repay/create-ui/0.4.2`
3. Run `create-repay-ui test-app`.  You can choose JS, TS, or do both.
4. `cd` into the generated app, and make sure that `yarn test` runs without any errors.