### PR TITLE
CACTUS-279: babel-plugin-styled-components

### DIFF
--- a/modules/babel-preset/index.js
+++ b/modules/babel-preset/index.js
@@ -92,12 +92,12 @@ module.exports = function babelPreset(
       [
         require('babel-plugin-styled-components').default,
         {
-          "displayName": true,
-          "ssr": false,
-          "fileName": false,
-          "pure": true,
-        }
-      ]
+          displayName: true,
+          ssr: false,
+          fileName: false,
+          pure: true,
+        },
+      ],
     ].filter(Boolean),
   }
 }

--- a/modules/babel-preset/index.js
+++ b/modules/babel-preset/index.js
@@ -89,6 +89,15 @@ module.exports = function babelPreset(
       // addes dynamic import syntax
       require('@babel/plugin-syntax-dynamic-import').default,
       isEnvTest && require('babel-plugin-dynamic-import-node').default,
+      [
+        require('babel-plugin-styled-components').default,
+        {
+          "displayName": true,
+          "ssr": false,
+          "fileName": false,
+          "pure": true,
+        }
+      ]
     ].filter(Boolean),
   }
 }

--- a/modules/babel-preset/package.json
+++ b/modules/babel-preset/package.json
@@ -17,7 +17,8 @@
     "@babel/preset-env": "^7.12.11",
     "@babel/preset-react": "^7.12.10",
     "@babel/preset-typescript": "^7.12.7",
-    "babel-plugin-dynamic-import-node": "^2.3.3"
+    "babel-plugin-dynamic-import-node": "^2.3.3",
+    "babel-plugin-styled-components": "^1.12.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2480,6 +2480,18 @@
   dependencies:
     "@types/node" ">= 8"
 
+"@repay/eslint-config@./modules/eslint-config":
+  version "5.0.0"
+  dependencies:
+    "@babel/eslint-parser" "^7.12.17"
+    "@typescript-eslint/eslint-plugin" "^4.13.0"
+    "@typescript-eslint/parser" "^4.13.0"
+    eslint-config-prettier "^7.1.0"
+    eslint-plugin-prettier "^3.3.1"
+    eslint-plugin-react "^7.22.0"
+    eslint-plugin-react-hooks "^4.2.0"
+    eslint-plugin-simple-import-sort "^7.0.0"
+
 "@rollup/plugin-babel@^5.2.2":
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.2.2.tgz#e5623a01dd8e37e004ba87f2de218c611727d9b2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,6 +53,13 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
+"@babel/helper-annotate-as-pure@^7.0.0":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.13.tgz#0f58e86dfc4bb3b1fcd7db806570e177d439b6ab"
+  integrity sha512-7YXfX5wQ5aYM/BOlbSccHDbuXXFPxeoUmfWtz8le2yTkTZc+BxsiEnENFoi2SlmA8ewDkG2LgIMIVzzn2h8kfw==
+  dependencies:
+    "@babel/types" "^7.12.13"
+
 "@babel/helper-annotate-as-pure@^7.10.4", "@babel/helper-annotate-as-pure@^7.12.10":
   version "7.12.10"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.10.tgz#54ab9b000e60a93644ce17b3f37d313aaf1d115d"
@@ -143,6 +150,13 @@
   integrity sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==
   dependencies:
     "@babel/types" "^7.12.7"
+
+"@babel/helper-module-imports@^7.0.0":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz#ec67e4404f41750463e455cc3203f6a32e93fcb0"
+  integrity sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==
+  dependencies:
+    "@babel/types" "^7.12.13"
 
 "@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.12.1", "@babel/helper-module-imports@^7.12.5":
   version "7.12.5"
@@ -957,6 +971,15 @@
   version "7.12.12"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.12.tgz#4608a6ec313abbd87afa55004d373ad04a96c299"
   integrity sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.12.11"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.12.13":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.13.0.tgz#74424d2816f0171b4100f0ab34e9a374efdf7f80"
+  integrity sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==
   dependencies:
     "@babel/helper-validator-identifier" "^7.12.11"
     lodash "^4.17.19"
@@ -2457,18 +2480,6 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@repay/eslint-config@./modules/eslint-config":
-  version "4.0.0"
-  dependencies:
-    "@babel/eslint-parser" "^7.12.17"
-    "@typescript-eslint/eslint-plugin" "^4.13.0"
-    "@typescript-eslint/parser" "^4.13.0"
-    eslint-config-prettier "^7.1.0"
-    eslint-plugin-prettier "^3.3.1"
-    eslint-plugin-react "^7.22.0"
-    eslint-plugin-react-hooks "^4.2.0"
-    eslint-plugin-simple-import-sort "^7.0.0"
-
 "@rollup/plugin-babel@^5.2.2":
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.2.2.tgz#e5623a01dd8e37e004ba87f2de218c611727d9b2"
@@ -3587,6 +3598,21 @@ babel-plugin-module-resolver@^4.0.0:
     pkg-up "^3.1.0"
     reselect "^4.0.0"
     resolve "^1.13.1"
+
+babel-plugin-styled-components@^1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.12.0.tgz#1dec1676512177de6b827211e9eda5a30db4f9b9"
+  integrity sha512-FEiD7l5ZABdJPpLssKXjBUJMYqzbcNzBowfXDCdJhOpbhWiewapUaY+LZGT8R4Jg2TwOjGjG4RKeyrO5p9sBkA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-module-imports" "^7.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.11"
+
+babel-plugin-syntax-jsx@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
+  integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
 
 babel-plugin-syntax-trailing-function-commas@^6.22.0:
   version "6.22.0"


### PR DESCRIPTION
Installing and testing the `babel plugin styled-components` to enhance debugging and bundle size.

[CACTUS-279](https://repayonline.atlassian.net/browse/CACTUS-279)

Following the documentation related to the babel-plugin-styled-components, I decided to divide what I’ve found after installing the plugin into our UI-tools into the different features offered by this plugin. Please let me know if there is something I’m missing. 

Server-side rendering

Thought that we don’t need this enabled, so I decided to disabled this option.

Better debugging

By doing a quick inspection of the DOM elements with the browser’s devTools,  you could notice that the classes of the elements now have interesting prefixes that show to us the name of the components. I think this is an interesting feature, now we have something like `TextInput-ffikND giNrcz` or `ContentWrapper-gCHCwG bkUZoZ` that helps us by identifying which styles are being applied to our elements, in the case that a single element is affected with more than one styled component.  

Using the React DevTools, the plugin gave us the display name of the component, honestly, I didn’t work too much with the React DevTools in this project, but this is better than just see something like the styled.div or styled.button, I’ve found this very comfortable. 

Noticed that I configured the plugin with the fileName option in false. It supposes that with this option disabled, I can see the displayName of the components without being prefixed with their filename. 

There is another feature that ensures that all of our class names will be unique. The documentation says that this is handy when we are working with micro frontends. 

Minification

This point makes me very curious about the difference in the bundle sizes of every cactus project before and after using this plugin, I compared the bundle sizes before and after the installation of the plugin, and those are the differences (Yes, I know not every module is using styled-components, but I listed all of them just to be sure)

Cactus-fwk: same size.

Cactus-theme: same size.

Cactus-icon: Bundle size increased from 233.37 KB to 238.76 KB

Cactus-web: the bundle size has decreased from 544.82 KB to 510.17 KB

Cactus-i18n: same size.

NOTE: Those values are obtained with this options object: require('babel-plugin-styled-components').default,
```
        {
          "displayName": true,
          "ssr": false,
          "fileName": false,
          "pure": true,
        }
```

In relation to the feature that drops the dead code and the transpilation of the template literals, I would like to ask you guys how can I compare the way babel is transpiling the tagged template literals before and after the implementation of this plugin.

I’ve found this plugin very interesting. I haven't discovered any visual changes after using this plugin inside the cactus modules.