### PR TITLE
CACTUS-543: dependency upgrade

### DIFF
--- a/modules/create-repay-ui/_templates/templates/javascript/packagejson.ejs.t
+++ b/modules/create-repay-ui/_templates/templates/javascript/packagejson.ejs.t
@@ -16,7 +16,7 @@ to: <%=directory%>/<%=name%>/package.json
   "keywords": [],
   "license": "MIT",
   "dependencies": {
-    "@repay/cactus-web": "^4.3.0",
+    "@repay/cactus-web": "^6.0.0",
     "react-router-dom": "^5.2.0",
     "axios": "^0.21.1",
     "prop-types": "^15.7.2",
@@ -28,7 +28,7 @@ to: <%=directory%>/<%=name%>/package.json
   "devDependencies": {
     "@babel/core": "^7.11.1",
     "@repay/babel-preset": "^1.0.1",
-    "@repay/eslint-config": "^3.2.0",
+    "@repay/eslint-config": "^5.0.0",
     "@repay/scripts": "^2.0.1",
     "@testing-library/jest-dom": "^5.11.2",
     "@testing-library/react": "^11.0.4",

--- a/modules/create-repay-ui/_templates/templates/typescript/packagejson.ejs.t
+++ b/modules/create-repay-ui/_templates/templates/typescript/packagejson.ejs.t
@@ -17,7 +17,7 @@ to: <%=directory%>/<%=name%>/package.json
   "keywords": [],
   "license": "MIT",
   "dependencies": {
-    "@repay/cactus-web": "^4.3.0",
+    "@repay/cactus-web": "^6.0.0",
     "react-router-dom": "^5.2.0",
     "axios": "^0.21.1",
     "prop-types": "^15.7.2",
@@ -29,7 +29,7 @@ to: <%=directory%>/<%=name%>/package.json
   "devDependencies": {
     "@babel/core": "^7.11.1",
     "@repay/babel-preset": "^1.0.1",
-    "@repay/eslint-config": "^3.2.0",
+    "@repay/eslint-config": "^5.0.0",
     "@repay/scripts": "^2.0.1",
     "@testing-library/jest-dom": "^5.11.2",
     "@testing-library/react": "^11.0.4",


### PR DESCRIPTION
@repay/cactus-web and @repay/eslint-config were been upgraded to 6.0.0 and 5.0.0 respectively

[CACTUS-543](https://repayonline.atlassian.net/browse/CACTUS-543)

Not sure if there is something I have to do to complete this ticket, please let me know in that case! 
