### PR TITLE
Temporarily downgrade node to v14 in CI to fix tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/node:lts-browsers
+      - image: circleci/node:14-browsers
 
     working_directory: ~/code
 


### PR DESCRIPTION
Much like in Cactus, we're running into problems after node changing their LTS version to 16.  For now, lets just downgrade to v14.  I've created three tech debt tickets in our backlog to allow us to spend time upgrading/fixing tests in each of our repos.