### PR TITLE
CACTUS-776 :: Upgrade node in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/node:14-browsers
+      - image: circleci/node:lts-browsers
 
     working_directory: ~/code
 

--- a/modules/testing-tools/package.json
+++ b/modules/testing-tools/package.json
@@ -21,6 +21,7 @@
       "^.+\\.js": "babel-jest"
     },
     "testRegex": "tests/.*\\.test\\.js",
+    "setupFilesAfterEnv": ["./tests/setup.js"],
     "verbose": true,
     "coverageReporters": [
       "lcov",

--- a/modules/testing-tools/tests/build-timed-test.test.js
+++ b/modules/testing-tools/tests/build-timed-test.test.js
@@ -24,9 +24,7 @@ beforeEach(() => {
 describe('Timed Test Builder', () => {
   test('should call before', async () => {
     global.test = getMockTest('0:00')
-    const beforeFn = jest.fn(async () => {
-      // do nothing
-    })
+    const beforeFn = jest.fn()
     const runTest = buildTimedTest({ before: beforeFn })
     await runTest('Test-ception', async () => {
       // do nothing
@@ -35,9 +33,7 @@ describe('Timed Test Builder', () => {
   })
   test('should call after', async () => {
     global.test = getMockTest('0:00')
-    const afterFn = jest.fn(async () => {
-      // do nothing
-    })
+    const afterFn = jest.fn()
     const runTest = buildTimedTest({ after: afterFn })
     await runTest('Test-ception', async () => {
       // do nothing
@@ -47,9 +43,7 @@ describe('Timed Test Builder', () => {
   test('should call test function', async () => {
     global.test = getMockTest('0:00')
     const runTest = buildTimedTest()
-    const testFn = jest.fn(async () => {
-      // do nothing
-    })
+    const testFn = jest.fn()
     await runTest('Test-ception', testFn)
     expect(testFn).toHaveBeenCalled()
   })
@@ -57,9 +51,7 @@ describe('Timed Test Builder', () => {
     global.test = getMockTest('0:02')
     performance.now = jest.fn().mockReturnValueOnce(0).mockReturnValueOnce(2000)
     const runTest = buildTimedTest()
-    const testFn = jest.fn(async () => {
-      // do nothing
-    })
+    const testFn = jest.fn()
     await runTest('Test-ception', testFn)
   })
 })

--- a/modules/testing-tools/tests/setup.js
+++ b/modules/testing-tools/tests/setup.js
@@ -1,0 +1,3 @@
+const perf_hooks = require('perf_hooks')
+
+perf_hooks.performance = { now: jest.fn().mockReturnValue(0) }


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-776

Would've been easier to start using the global `performance` object since it exists globally now, but I didn't want to have to restrict our users to node >= 16.