### PR TITLE
CACTUS-870: change rollup config to work in more cases

### DIFF
--- a/modules/repay-scripts/src/configs/rollup.js
+++ b/modules/repay-scripts/src/configs/rollup.js
@@ -46,7 +46,7 @@ function getRollupConfig(input, { cwd, treeShaking, babelEnv }) {
         extensions: ['.js', '.jsx', '.ts', '.tsx', '.json', '.svg'],
       }),
       rollupCommonjs({
-        include: 'node_modules/**',
+        include: /node_modules/,
       }),
       rollupBabel({
         babelHelpers: babelEnv === 'test' ? 'bundled' : 'runtime',


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-870

I suggest testing it in two different cases.
1. `cd` to `modules/repay-scripts` and run `yalc publish`.
2. Use [this branch](https://github.com/repaygithub/ui-private/compare/cactus-870-uat). `cd` to `ui-private/modules/internal-components`. Before adding the updated module, try running `yarn build`; you should get an error.
3. Run `yalc add @repay/scripts`, then from the `ui-private` root run `yarn install`. Back in the `internal-components` directory, run `yarn build` again, and this time it should work.

The second case is `cactus-web`, but because of the ongoing dependency weirdness there, you can't just use `yalc`. Instead, just modify `cactus/node_modules/@repay/scripts/src/config/rollup.js` with the same change you see in this PR, and then run
```
yarn web repay-scripts build --lib --tree-shaking src/index.ts
```
(That's the same as `yarn build`, just without the rollup override.) Interestingly, the build worked even without the change (when I just removed the rollup config), so it's possible the override hasn't been needed in `cactus-web` for some time and it was just that no one realized & removed it.